### PR TITLE
Misplaced return statement in foundation.jl

### DIFF
--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -30,7 +30,6 @@ function loadbundle(path)
     bundle = [NSBundle bundleWithPath:path]
     bundle.ptr |> Int |> int2bool || error("Bundle $path not found")
     [bundle load] |> int2bool || error("Couldn't load bundle $path")
-    return
   end
 end
 

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -26,11 +26,11 @@ function Base.gc(obj::Object)
 end
 
 function loadbundle(path)
-  @objc begin
-    bundle = [NSBundle bundleWithPath:path]
-    bundle.ptr |> Int |> int2bool || error("Bundle $path not found")
-    [bundle load] |> int2bool || error("Couldn't load bundle $path")
-  end
+  bundle = @objc [NSBundle bundleWithPath:path]
+  bundle.ptr |> Int |> int2bool || error("Bundle $path not found")
+  loadedStuff = @objc [bundle load]
+  loadedStuff |> int2bool || error("Couldn't load bundle $path")
+  return
 end
 
 framework(name) = loadbundle("/System/Library/Frameworks/$name.framework")


### PR DESCRIPTION
Currently, trying to load this package on Julia v0.3.11 or greater produces the following error:

```julia
julia> using ObjectiveC
WARNING: Union(args...) is deprecated, use Union{args...} instead.
 in depwarn at deprecated.jl:73
 in call at deprecated.jl:50
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in require at ./loading.jl:243
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in require at ./loading.jl:243
while loading /Users/rje/.julia/v0.5/Lazy/src/liblazy.jl, in expression starting on line 93
WARNING: Union(args...) is deprecated, use Union{args...} instead.
 in depwarn at deprecated.jl:73
 in call at deprecated.jl:50
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in require at ./loading.jl:243
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in require at ./loading.jl:243
while loading /Users/rje/.julia/v0.5/Lazy/src/liblazy.jl, in expression starting on line 100
WARNING: Base.String is deprecated, use AbstractString instead.

WARNING: deprecated syntax "classes (" at /Users/rje/.julia/v0.5/ObjectiveC/src/syntax.jl:42.
Use "classes(" instead.
WARNING: Base.String is deprecated, use AbstractString instead.
WARNING: Base.String is deprecated, use AbstractString instead.

WARNING: deprecated syntax "class (" at /Users/rje/.julia/v0.5/ObjectiveC/src/classes.jl:76.
Use "class(" instead.
WARNING: Base.String is deprecated, use AbstractString instead.
ERROR: LoadError: LoadError: syntax: misplaced return statement
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in require at ./loading.jl:243
while loading /Users/rje/.julia/v0.5/ObjectiveC/src/foundation.jl, in expression starting on line 36
while loading /Users/rje/.julia/v0.5/ObjectiveC/src/ObjectiveC.jl, in expression starting on line 27
```

Removing the return on line 33 of foundation.jl fixes this and the package then loads. However, I am not sure if this any effect on intended behavior.

Best,
Rob